### PR TITLE
Load transaction aggregators on demand instead from the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,8 @@ practicing TDD and some software architecture decisions just for fun.
 
 ### How does it work
 
-1. It applies a concrete aggregator for each "transaction kind" group.
-2. The mapping with the aggregators by kind is in the `config.php`.
-
-```php
-return [
-    // ...
-    TransactionsHistoryConfig::TRANSACTION_AGGREGATORS_BY_TYPE => [
-        'crypto_exchange' => ToCurrencyAggregator::class,
-        'crypto_purchase' => CurrencyAggregator::class,
-        // ...
-```
+1. It applies a concrete aggregator for each transaction type group.
+2. The mapping with the aggregators is chosen on the fly when mapping the transactions. See `CsvHeadersTransactionMapper`.
 
 ### Commands
 

--- a/config/default.php
+++ b/config/default.php
@@ -2,22 +2,10 @@
 
 declare(strict_types=1);
 
-use App\TransactionsHistory\Domain\TransactionAggregator\CurrencyAggregator;
-use App\TransactionsHistory\Domain\TransactionAggregator\ToCurrencyAggregator;
 use App\TransactionsHistory\TransactionsHistoryConfig;
 
 return [
     TransactionsHistoryConfig::TOTAL_DECIMALS => 8,
     TransactionsHistoryConfig::TOTAL_NATIVE_DECIMALS => 2,
     TransactionsHistoryConfig::NATIVE_CURRENCY_KEY => 'EUR',
-    TransactionsHistoryConfig::TRANSACTION_AGGREGATORS_BY_TYPE => [
-        'crypto_deposit' => CurrencyAggregator::class,
-        'crypto_earn_interest_paid' => CurrencyAggregator::class,
-        'crypto_exchange' => ToCurrencyAggregator::class,
-        'crypto_purchase' => CurrencyAggregator::class,
-        'crypto_to_exchange_transfer' => CurrencyAggregator::class,
-        'crypto_viban_exchange' => ToCurrencyAggregator::class,
-        'crypto_withdrawal' => CurrencyAggregator::class,
-        'viban_purchase' => ToCurrencyAggregator::class,
-    ],
 ];

--- a/src/TransactionsHistory/Domain/Service/AggregateService.php
+++ b/src/TransactionsHistory/Domain/Service/AggregateService.php
@@ -78,7 +78,9 @@ final class AggregateService
         $result = [];
 
         foreach ($groupedTransactions as $type => $transactions) {
-            $aggregator = $this->transactionAggregators->getAggregatorByType($type);
+            /** @var Transaction $firstTransaction */
+            $firstTransaction = reset($transactions);
+            $aggregator = $this->transactionAggregators->getForTransaction($firstTransaction);
             $result[$type] = $aggregator->aggregate(...$transactions);
         }
 

--- a/src/TransactionsHistory/Domain/Transfer/Transaction.php
+++ b/src/TransactionsHistory/Domain/Transfer/Transaction.php
@@ -26,6 +26,8 @@ final class Transaction
 
     private string $transactionType = '';
 
+    private string $aggregatorClassName = '';
+
     public function getTimestampUtc(): string
     {
         return $this->timestampUtc;
@@ -142,6 +144,18 @@ final class Transaction
     public function setTransactionType(string $transactionType): self
     {
         $this->transactionType = $transactionType;
+
+        return $this;
+    }
+
+    public function getAggregatorClassName(): string
+    {
+        return $this->aggregatorClassName;
+    }
+
+    public function setAggregatorClassName(string $aggregatorClassName): self
+    {
+        $this->aggregatorClassName = $aggregatorClassName;
 
         return $this;
     }

--- a/src/TransactionsHistory/Domain/Transfer/TransactionAggregators.php
+++ b/src/TransactionsHistory/Domain/Transfer/TransactionAggregators.php
@@ -12,15 +12,15 @@ final class TransactionAggregators
     /** @var array<string,TransactionAggregatorInterface> */
     private array $aggregators = [];
 
-    public function put(string $transactionType, TransactionAggregatorInterface $aggregator): self
+    public function add(TransactionAggregatorInterface $aggregator): self
     {
-        $this->aggregators[$transactionType] = $aggregator;
+        $this->aggregators[get_class($aggregator)] = $aggregator;
 
         return $this;
     }
 
-    public function getAggregatorByType(string $transactionType): TransactionAggregatorInterface
+    public function getForTransaction(Transaction $transaction): TransactionAggregatorInterface
     {
-        return $this->aggregators[$transactionType] ?? new NullAggregator();
+        return $this->aggregators[$transaction->getAggregatorClassName()] ?? new NullAggregator();
     }
 }

--- a/src/TransactionsHistory/TransactionsHistoryConfig.php
+++ b/src/TransactionsHistory/TransactionsHistoryConfig.php
@@ -30,12 +30,4 @@ final class TransactionsHistoryConfig extends AbstractConfig
     {
         return $this->get(self::NATIVE_CURRENCY_KEY, null);// @phpstan-ignore-line
     }
-
-    /**
-     * @return array<string,class-string>
-     */
-    public function getTransactionAggregatorsByType(): array
-    {
-        return (array) $this->get(self::TRANSACTION_AGGREGATORS_BY_TYPE);// @phpstan-ignore-line
-    }
 }

--- a/src/TransactionsHistory/TransactionsHistoryDependencyProvider.php
+++ b/src/TransactionsHistory/TransactionsHistoryDependencyProvider.php
@@ -4,10 +4,6 @@ declare(strict_types=1);
 
 namespace App\TransactionsHistory;
 
-use App\TransactionsHistory\Domain\TransactionAggregator\CurrencyAggregator;
-use App\TransactionsHistory\Domain\TransactionAggregator\ToCurrencyAggregator;
-use App\TransactionsHistory\Domain\TransactionAggregator\TransactionAggregatorInterface;
-use App\TransactionsHistory\Domain\Transfer\TransactionAggregators;
 use Gacela\Framework\AbstractDependencyProvider;
 use Gacela\Framework\Container\Container;
 
@@ -18,46 +14,5 @@ final class TransactionsHistoryDependencyProvider extends AbstractDependencyProv
 {
     public function provideModuleDependencies(Container $container): void
     {
-        $this->addTransactionAggregators($container);
-        $this->addCurrencyAggregator($container);
-        $this->addToCurrencyAggregator($container);
-    }
-
-    /**
-     * This way, when the Factory needs to build the TransactionAggregators it will be build once and store as a
-     * singleton in the DependencyProvider.
-     */
-    private function addTransactionAggregators(Container $container): void
-    {
-        $container->set(TransactionAggregators::class, function(Container $container): TransactionAggregators {
-            $classNamesByType = $this->getConfig()->getTransactionAggregatorsByType();
-            $aggregators = new TransactionAggregators();
-
-            foreach ($classNamesByType as $transactionType => $className) {
-                /** @var TransactionAggregatorInterface $aggregator */
-                $aggregator = $container->get($className);
-                $aggregators->put($transactionType, $aggregator);
-            }
-
-            return $aggregators;
-        });
-    }
-
-    private function addCurrencyAggregator(Container $container): void
-    {
-        $container->set(CurrencyAggregator::class, fn() => new CurrencyAggregator(
-            $this->getConfig()->getTotalDecimals(),
-            $this->getConfig()->getTotalNativeDecimals(),
-            $this->getConfig()->getNativeCurrencyKey(),
-        ));
-    }
-
-    private function addToCurrencyAggregator(Container $container): void
-    {
-        $container->set(ToCurrencyAggregator::class, fn() => new ToCurrencyAggregator(
-            $this->getConfig()->getTotalDecimals(),
-            $this->getConfig()->getTotalNativeDecimals(),
-            $this->getConfig()->getNativeCurrencyKey(),
-        ));
     }
 }

--- a/tests/Unit/TransactionsHistory/Domain/Service/AggregateServiceTest.php
+++ b/tests/Unit/TransactionsHistory/Domain/Service/AggregateServiceTest.php
@@ -12,49 +12,48 @@ use App\TransactionsHistory\Domain\Transfer\Transaction;
 use App\TransactionsHistory\Domain\Transfer\TransactionAggregators;
 use PHPUnit\Framework\TestCase;
 
-final class StatisticsServiceTest extends TestCase
+final class AggregateServiceTest extends TestCase
 {
-    public function test_service_with_multiple_transaction_kinds(): void
+    public function test_service_with_multiple_transaction_types(): void
     {
         $transactions = [
             [
-                'Transaction Kind Header' => 'transaction kind 1',
+                'Transaction Kind Header' => 'transaction type 1',
             ],
             [
-                'Transaction Kind Header' => 'transaction kind 1',
+                'Transaction Kind Header' => 'transaction type 1',
             ],
             [
-                'Transaction Kind Header' => 'transaction kind 2',
+                'Transaction Kind Header' => 'transaction type 2',
             ],
         ];
 
         $fileReaderService = $this->createMock(FileReaderServiceInterface::class);
         $fileReaderService->method('read')->with('fake-file-path')->willReturn($transactions);
 
+        $aggregator = new class() implements TransactionAggregatorInterface {
+            public function aggregate(Transaction ...$transactions): array
+            {
+                return ['type' => 'manager'];
+            }
+        };
+
         $transactionMapper = $this->createMock(TransactionMapperInterface::class);
         $transactionMapper->method('map')->willReturnCallback(
-            fn(array $row) => (new Transaction())->setTransactionType($row['Transaction Kind Header'])
+            fn(array $row) => (new Transaction())
+                ->setTransactionType($row['Transaction Kind Header'])
+                ->setAggregatorClassName(get_class($aggregator))
         );
-
-        $kind1Aggregator = $this->createMock(TransactionAggregatorInterface::class);
-        $kind1Aggregator->method('aggregate')->willReturn(['kind 1' => 'manager']);
-
-        $kind2Aggregator = $this->createMock(TransactionAggregatorInterface::class);
-        $kind2Aggregator->method('aggregate')->willReturn(['kind 2' => 'manager']);
-
-        $transactionManagers = (new TransactionAggregators())
-            ->put('transaction kind 1', $kind1Aggregator)
-            ->put('transaction kind 2', $kind2Aggregator);
 
         $statisticsService = new AggregateService(
             $fileReaderService,
             $transactionMapper,
-            $transactionManagers,
+            (new TransactionAggregators())->add($aggregator),
         );
 
         self::assertEquals([
-            'transaction kind 1' => ['kind 1' => 'manager'],
-            'transaction kind 2' => ['kind 2' => 'manager'],
+            'transaction type 1' => ['type' => 'manager'],
+            'transaction type 2' => ['type' => 'manager'],
         ], $statisticsService->forFilepath('fake-file-path'));
     }
 }


### PR DESCRIPTION
## 🔖 Changes

Currently, in the config you specify the `[transaction type => transaction aggregator]`. I lifted this up to be the responsability of the transaction itself when built it on the Mapper (`CsvHeadersTransactionMapper`) where I set the new field `$transaction->setAggregatorClassName(...)`.